### PR TITLE
Update for Bluehawk 1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "bluehawk-plugin-git",
       "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
@@ -20,7 +21,7 @@
         "@babel/preset-typescript": "^7.13.0",
         "@types/node": "^14.14.31",
         "@types/rimraf": "^3.0.0",
-        "@types/yargs": "^16.0.0",
+        "@types/yargs": "^17.0.10",
         "@typescript-eslint/eslint-plugin": "^4.16.1",
         "@typescript-eslint/parser": "^4.16.1",
         "eslint": "^7.21.0",
@@ -1050,9 +1051,9 @@
       }
     },
     "node_modules/@jest/types/node_modules/@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -1563,9 +1564,9 @@
       "dev": true
     },
     "node_modules/@types/yargs": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.0.tgz",
-      "integrity": "sha512-2nN6AGeMwe8+O6nO9ytQfbMQOJy65oi1yK2y/9oReR08DaXSGtMsrLyCM1ooKqfICpCx4oITaR4LkOmdzz41Ww==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -6349,9 +6350,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -11894,9 +11895,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "15.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -12366,9 +12367,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.0.tgz",
-      "integrity": "sha512-2nN6AGeMwe8+O6nO9ytQfbMQOJy65oi1yK2y/9oReR08DaXSGtMsrLyCM1ooKqfICpCx4oITaR4LkOmdzz41Ww==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -16208,9 +16209,9 @@
       },
       "dependencies": {
         "@types/yargs": {
-          "version": "15.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@types/node": "^14.14.31",
     "@types/rimraf": "^3.0.0",
-    "@types/yargs": "^16.0.0",
+    "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "eslint": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.2.2"
   },
   "dependencies": {
-    "bluehawk": "^0",
+    "bluehawk": "^1.0.0",
     "rimraf": "^3.0.2",
     "simple-git": "^2.35.2"
   }

--- a/src/commands/git-copy.ts
+++ b/src/commands/git-copy.ts
@@ -2,12 +2,14 @@ import { strict as assert } from "assert";
 import _rimraf from "rimraf";
 import { promises as fs } from "fs";
 import * as Path from "path";
-import { copy, MainArgs, withIgnoreOption, withStateOption } from "bluehawk";
+import { copy, ActionArgs, withIgnoreOption, withStateOption, ConsoleActionReporter } from "bluehawk";
 import simpleGit from "simple-git";
 import { CommandModule } from "yargs";
 
+const reporter = new ConsoleActionReporter();
+
 const commandModule: CommandModule<
-  MainArgs & { rootPath: string },
+  ActionArgs & { rootPath: string },
   GitCopyArgs
 > = {
   command: "copy <rootPath>",
@@ -38,7 +40,7 @@ const commandModule: CommandModule<
   aliases: [],
 };
 
-export interface GitCopyArgs extends MainArgs {
+export interface GitCopyArgs extends ActionArgs {
   rootPath: string;
   state?: string;
   ignore?: string | string[];
@@ -102,14 +104,14 @@ export async function gitCopy(args: GitCopyArgs): Promise<void> {
     }
 
     console.log("Copying...");
-    const errors = await copy({
+    await copy({
       rootPath,
       ignore,
       state,
-      destination: clonePath,
+      output: clonePath,
+      reporter: reporter,
       waitForListeners: true,
     });
-    assert(errors.length === 0);
     console.log(
       `Copy complete. Files:\n${(
         await listFilesInTreeExceptGit(clonePath)


### PR DESCRIPTION
- Updates yargs to ^17
- Adds a `ConsoleActionReporter` for `git-copy`
- Converts to the v1 copy interface (i.e. `output` instead of `destination`)